### PR TITLE
This PR reworks protection of the PathMap

### DIFF
--- a/prom.go
+++ b/prom.go
@@ -95,11 +95,11 @@ func New(options ...func(*Prometheus)) *Prometheus {
 }
 
 func (p *Prometheus) update() {
+	p.PathMap.Lock()
+	p.Ignored.RLock()
 	if p.PathMap.values == nil {
 		p.PathMap.values = make(map[string]string)
 	}
-	p.PathMap.Lock()
-	p.Ignored.RLock()
 	defer func() {
 		p.PathMap.Unlock()
 		p.Ignored.RUnlock()
@@ -164,7 +164,9 @@ func (p *Prometheus) register() {
 // single handler
 func (p *Prometheus) Instrument() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		p.PathMap.RLock()
 		if p.PathMap.values == nil {
+			p.PathMap.RUnlock()
 			p.update()
 		}
 		var path string


### PR DESCRIPTION
1. Add the new `TestThreadedInstrument` function to the prom_test.go file
2. Run `go test -race` and you should see this:

```
WARNING: DATA RACE
Read at 0x00c00020c598 by goroutine 31:
  github.com/Depado/ginprom.(*Prometheus).Instrument.func1()
      /Users/matthew/lab/ginprom/prom.go:167 +0x6d
  github.com/gin-gonic/gin.(*Context).Next()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/context.go:108 +0xc6
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/gin.go:361 +0x930
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/gin.go:326 +0x249
  github.com/appleboy/gofight.(*RequestConfig).Run()
      /Users/matthew/go/pkg/mod/github.com/appleboy/gofight@v2.0.0+incompatible/gofight.go:311 +0x75
  github.com/Depado/ginprom.TestInstrument.func2()
      /Users/matthew/lab/ginprom/prom_test.go:112 +0x229

Previous write at 0x00c00020c598 by goroutine 17:
  github.com/Depado/ginprom.(*Prometheus).update()
      /Users/matthew/lab/ginprom/prom.go:101 +0x326
  github.com/Depado/ginprom.(*Prometheus).Instrument.func1()
      /Users/matthew/lab/ginprom/prom.go:168 +0x606
  github.com/gin-gonic/gin.(*Context).Next()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/context.go:108 +0xc6
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/gin.go:361 +0x930
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /Users/matthew/go/pkg/mod/github.com/gin-gonic/gin@v1.3.0/gin.go:326 +0x249
  github.com/appleboy/gofight.(*RequestConfig).Run()
      /Users/matthew/go/pkg/mod/github.com/appleboy/gofight@v2.0.0+incompatible/gofight.go:311 +0x75
  github.com/Depado/ginprom.TestInstrument.func2()
      /Users/matthew/lab/ginprom/prom_test.go:112 +0x229
```
