### PR TITLE
Providing namespace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ func main() {
 Specify the path on which the metrics are accessed  
 Default : "/metrics"
 
+`Namespace(ns string)`  
+Specify the namespace  
+Default : "gin"
+
 `Subsystem(sub string)`  
 Specify the subsystem  
-Default : "gin"
+Default : "go"
 
 `Engine(e *gin.Engine)`  
 Specify the Gin engine directly when initializing. 
@@ -74,7 +78,8 @@ function after the initialization like this :
 
 ```go
 p := ginprom.New(
-	ginprom.Subsystem("gin"), 
+	ginprom.Namespace("gin"), 
+	ginprom.Subsystem("gonic"), 
 	ginprom.Path("/metrics"), 
 )
 p.Use(r)

--- a/prom_test.go
+++ b/prom_test.go
@@ -59,6 +59,23 @@ func TestEngine(t *testing.T) {
 	unregister(p)
 }
 
+func TestNamespace(t *testing.T) {
+	p := New()
+	assert.Equal(t, p.Namespace, defaultNs, "namespace should be default")
+	unregister(p)
+
+	tests := []string{
+		"test",
+		"",
+		"_",
+	}
+	for _, test := range tests {
+		p = New(Namespace(test))
+		assert.Equal(t, p.Namespace, test, "should match")
+		unregister(p)
+	}
+}
+
 func TestSubsystem(t *testing.T) {
 	p := New()
 	assert.Equal(t, p.Subsystem, defaultSys, "subsystem should be default")


### PR DESCRIPTION
Closes #3.

Tests result:

```
GOROOT=/usr/local/Cellar/go/1.11/libexec #gosetup
GOPATH=/Users/prometherion/go #gosetup
/usr/local/Cellar/go/1.11/libexec/bin/go test -c -covermode=atomic -i -o /private/var/folders/m8/vsxn7w5n0ssbgqfsff9q4wmm0000gn/T/_________in_github_com_prometherion_ginprom github.com/prometherion/ginprom #gosetup
/usr/local/Cellar/go/1.11/libexec/bin/go tool test2json -t /private/var/folders/m8/vsxn7w5n0ssbgqfsff9q4wmm0000gn/T/_________in_github_com_prometherion_ginprom -test.v -test.run ./... -test.coverprofile /Users/prometherion/Library/Caches/GoLand2018.3/coverage/ginprom$______in_github_com_prometherion_ginprom.out #gosetup
=== RUN   TestPrometheus_Use
--- PASS: TestPrometheus_Use (0.00s)
=== RUN   TestPath
--- PASS: TestPath (0.00s)
=== RUN   TestEngine
--- PASS: TestEngine (0.00s)
=== RUN   TestNamespace
--- PASS: TestNamespace (0.00s)
=== RUN   TestSubsystem
--- PASS: TestSubsystem (0.00s)
=== RUN   TestUse
--- PASS: TestUse (0.00s)
=== RUN   TestInstrument
--- PASS: TestInstrument (0.00s)
=== RUN   TestThreadedInstrument
--- PASS: TestThreadedInstrument (0.00s)
=== RUN   TestEmptyRouter
--- PASS: TestEmptyRouter (0.00s)
=== RUN   TestIgnore
--- PASS: TestIgnore (0.00s)
=== RUN   TestMetricsPathIgnored
--- PASS: TestMetricsPathIgnored (0.00s)
PASS
coverage: 100.0% of statements

Process finished with exit code 0
```