### PR TITLE
feat(token): support custom token from prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ginprom
+
 Gin Prometheus metrics exporter inspired by [github.com/zsais/go-gin-prometheus](https://github.com/zsais/go-gin-prometheus)
 
 ![Go Version](https://img.shields.io/badge/go-1.9-brightgreen.svg)
@@ -7,7 +8,6 @@ Gin Prometheus metrics exporter inspired by [github.com/zsais/go-gin-prometheus]
 [![Build Status](https://drone.depado.eu/api/badges/Depado/ginprom/status.svg)](https://drone.depado.eu/Depado/ginprom)
 [![codecov](https://codecov.io/gh/Depado/ginprom/branch/master/graph/badge.svg)](https://codecov.io/gh/Depado/ginprom)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Depado/bfchroma/blob/master/LICENSE)
-
 
 ## Install
 
@@ -35,8 +35,8 @@ func main() {
 	r := gin.Default()
 	p := ginprom.New(
 		ginprom.Engine(r),
-		ginprom.Subsystem("gin"), 
-		ginprom.Path("/metrics"), 
+		ginprom.Subsystem("gin"),
+		ginprom.Path("/metrics"),
 	)
 	r.Use(p.Instrument())
 
@@ -61,26 +61,29 @@ Specify the subsystem
 Default : "go"
 
 `Engine(e *gin.Engine)`  
-Specify the Gin engine directly when initializing. 
-Saves a call to `Use(e *gin.Engine)`  
+Specify the Gin engine directly when initializing.
+Saves a call to `Use(e *gin.Engine)`
 Default : `nil`
 
-`Ignore(paths ...string)`   
+`Ignore(paths ...string)`
 Specify which paths should not be taken into account by the middleware.
+
+`Token(token string)`
+Specify the token from prometheus. It is returned when the api request token is invalid.
 
 ## Troubleshooting
 
 ### The instrumentation doesn't seem to work
 
 Make sure you have set the `gin.Engine` in the `ginprom` middleware, either when
-initializing it using `ginprom.New(ginprom.Engine(r))` or using the `Use` 
+initializing it using `ginprom.New(ginprom.Engine(r))` or using the `Use`
 function after the initialization like this :
 
 ```go
 p := ginprom.New(
-	ginprom.Namespace("gin"), 
-	ginprom.Subsystem("gonic"), 
-	ginprom.Path("/metrics"), 
+	ginprom.Namespace("gin"),
+	ginprom.Subsystem("gonic"),
+	ginprom.Path("/metrics"),
 )
 p.Use(r)
 r.Use(p.Instrument())


### PR DESCRIPTION
Set bearer token in Prometheus as the following:

```yaml
scrape_configs:
  - job_name: 'ggz-server'
    static_configs:
      - targets: ['ggz-server:8080']
    bearer_token: 'test-prometheus-token'
```