### PR TITLE
chore: upgrade to go1.13

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,25 +9,21 @@ steps:
   - git fetch --tags
 
 - name: test
-  image: golang:latest
+  image: golang:1.13
   volumes:
   - name: deps
     path: /go
   commands:
   - go test -race -coverprofile=coverage.txt -covermode=atomic
-  environment:
-    GO111MODULE: "on"
 
 - name: linter
-  image: golang:latest
+  image: golang:1.13
   volumes:
   - name: deps
     path: /go
   commands:
     - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.17.1
     - ./bin/golangci-lint run
-  environment:
-    GO111MODULE: "on"
 
 - name: coverage
   image: plugins/codecov
@@ -45,8 +41,8 @@ steps:
     token:
       from_secret: telegram_token
     message: >
-      *{{repo.name}}*  
-      [Build {{build.number}}]({{build.link}}) by {{commit.author}} {{#success build.status}}succeeded{{else}}failed{{/success}} in {{buildtime build.started}}  
+      *{{repo.name}}*
+      [Build {{build.number}}]({{build.link}}) by {{commit.author}} {{#success build.status}}succeeded{{else}}failed{{/success}} in {{buildtime build.started}}
       `{{truncate commit.sha 8}}`: "{{commit.message}}"
   when:
     status:


### PR DESCRIPTION
go module is enabled as default in `go1.13` version.

> The GO111MODULE environment variable continues to default to auto, but the auto setting now activates the module-aware mode of the go command whenever the current working directory contains, or is below a directory containing, a go.mod file — even if the current directory is within GOPATH/src. This change simplifies the migration of existing code within GOPATH/src and the ongoing maintenance of module-aware packages alongside non-module-aware importers.

https://tip.golang.org/doc/go1.13#modules