### PR TITLE
Providing request buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ p := ginprom.New(
 r.Use(p.Instrument())
 ```
 
+### Bucket size
+
+Specify the bucket size for the request duration histogram according to your
+expected durations.
+
+```go
+r := gin.New()
+p := ginprom.New(
+	ginprom.Engine(r),
+	ginprom.BucketSize([]float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}),
+)
+r.Use(p.Instrument())
+```
+
 ## Troubleshooting
 
 ### The instrumentation doesn't seem to work

--- a/prom_test.go
+++ b/prom_test.go
@@ -132,6 +132,17 @@ func TestUse(t *testing.T) {
 	unregister(p)
 }
 
+func TestBucketSize(t *testing.T) {
+	p := New()
+	assert.Nil(t, p.BucketsSize, "namespace should be default")
+	unregister(p)
+
+	bs := []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
+	p = New(BucketSize(bs))
+	assert.Equal(t, p.BucketsSize, bs, "should match")
+	unregister(p)
+}
+
 func TestInstrument(t *testing.T) {
 	r := gin.New()
 	p := New(Engine(r))


### PR DESCRIPTION
With buckets, we can calculate the latency for a single path and method.

This is a breaking change since we're deprecating the `NAMESPACE_SUBSYSTEM_request_duration_seconds_{sum,count}` metrics to let them calculate with a higher cardinality.

Although, providing fallback should be quite easy, something like this:

```
# replacing NAMESPACE_SUBSYSTEM_request_duration_seconds_count
sum(NAMESPACE_SUBSYSTEM_request_duration_buckets_count)

# replacing NAMESPACE_SUBSYSTEM_request_duration_seconds_sum
sum(NAMESPACE_SUBSYSTEM_request_duration_buckets_sum)
```