### PR TITLE
Add option to use a custom prometheus.Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ r.Use(p.Instrument())
 
 ```
 
+### Prometheus Registry
+
+Use a custom `prometheus.Registry` instead of prometheus client's global registry. This option allows
+to use ginprom in multiple gin engines in the same process, or if you would like to integrate ginprom with your own
+prometheus `Registry`.
+
+```go
+registry := prometheus.NewRegistry() // creates new prometheus metric registry
+r := gin.New()
+p := ginprom.New(
+    ginprom.Registry(registry),
+)
+r.Use(p.Instrument())
+```
+
 ### Ignore
 
 Ignore allows to completely ignore some routes. Even though you can apply the

--- a/prom_test.go
+++ b/prom_test.go
@@ -82,6 +82,13 @@ func TestEngine(t *testing.T) {
 	unregister(p)
 }
 
+func TestRegistry(t *testing.T)  {
+	registry := prometheus.NewRegistry()
+
+	p := New(Registry(registry))
+	assert.Equal(t, p.Registry, registry)
+}
+
 func TestNamespace(t *testing.T) {
 	p := New()
 	assert.Equal(t, p.Namespace, defaultNs, "namespace should be default")
@@ -377,4 +384,15 @@ func TestInstrumentCustomMetricsErrors(t *testing.T) {
 	})
 
 	unregister(p)
+}
+
+func TestMultipleGinWithDifferentRegistry(t *testing.T)  {
+	// with different registries we don't panic because of multiple metric registration attempt
+	r1 := gin.New()
+	p1 := New(Engine(r1), Registry(prometheus.NewRegistry()))
+	r1.Use(p1.Instrument())
+
+	r2 := gin.New()
+	p2 := New(Engine(r2), Registry(prometheus.NewRegistry()))
+	r2.Use(p2.Instrument())
 }


### PR DESCRIPTION
This option allows to use ginprom in multiple gin engines hosted by the same go process, or if
you already have a custom Registry you can use that too with ginprom