### PR TITLE
Add host label to request duration counter

### DIFF
--- a/prom.go
+++ b/prom.go
@@ -275,7 +275,7 @@ func (p *Prometheus) register() {
 		Buckets:   p.BucketsSize,
 		Name:      p.RequestDurationMetricName,
 		Help:      "The HTTP request latency bucket.",
-	}, []string{"method", "path"})
+	}, []string{"method", "path", "host"})
 	registerer.MustRegister(p.reqDur)
 
 	p.reqSz = prometheus.NewSummary(
@@ -327,7 +327,7 @@ func (p *Prometheus) Instrument() gin.HandlerFunc {
 		resSz := float64(c.Writer.Size())
 
 		p.reqCnt.WithLabelValues(status, c.Request.Method, c.HandlerName(), c.Request.Host, path).Inc()
-		p.reqDur.WithLabelValues(c.Request.Method, path).Observe(elapsed)
+		p.reqDur.WithLabelValues(c.Request.Method, path, c.Request.Host).Observe(elapsed)
 		p.reqSz.Observe(float64(reqSz))
 		p.resSz.Observe(resSz)
 	}


### PR DESCRIPTION
This adds host label to request duration counter to be just like the request counter label.

Fixes #21 
