### PR TITLE
feat: add support for custom labels in the  counter metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,13 +234,12 @@ r.Use(p.Instrument())
 
 ### CustomCounterLabels
 
-Add custom labels to the counter metric. This option is useful when wanting to
-add custom labels to the counter metric.
+Add custom labels to the counter metric.
 
 ```go
 r := gin.Default()
 p := ginprom.New(
-  ginprom.CustomLabels([]string{"client_id"}, func(c *gin.Context) map[string]string {
+  ginprom.CustomCounterLabels([]string{"client_id"}, func(c *gin.Context) map[string]string {
     client_id := c.GetHeader("x-client-id")
     if client_id == "" {
       client_id = "unknown"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Inspired by [github.com/zsais/go-gin-prometheus](https://github.com/zsais/go-gin
 	- [Subsystem](#subsystem)
 	- [Engine](#engine)
 	- [Prometheus Registry](#prometheus-registry)
+	- [HandlerNameFunc](#handlernamefunc)
+	- [RequestPathFunc](#requestpathfunc)
+	- [CustomCounterLabels](#customcounterlabels)
 	- [Ignore](#ignore)
 	- [Token](#token)
 	- [Bucket size](#bucket-size)
@@ -225,6 +228,25 @@ p := ginprom.New(
 		}
 		return "<unknown>"
 	}),
+)
+r.Use(p.Instrument())
+```
+
+### CustomCounterLabels
+
+Add custom labels to the counter metric. This option is useful when wanting to
+add custom labels to the counter metric.
+
+```go
+r := gin.Default()
+p := ginprom.New(
+  ginprom.CustomLabels([]string{"client_id"}, func(c *gin.Context) map[string]string {
+    client_id := c.GetHeader("x-client-id")
+    if client_id == "" {
+      client_id = "unknown"
+    }
+    return map[string]string{"client_id": client_id}
+  }),
 )
 r.Use(p.Instrument())
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Depado/ginprom
+module github.com/sralloza/ginprom
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sralloza/ginprom
+module github.com/Depado/ginprom
 
 go 1.20
 

--- a/options.go
+++ b/options.go
@@ -151,3 +151,10 @@ func RequestPathFunc(f func(c *gin.Context) string) PrometheusOption {
 		p.RequestPathFunc = f
 	}
 }
+
+func CustomCounterLabels(labels []string, f func(c *gin.Context) map[string]string) PrometheusOption {
+	return func(p *Prometheus) {
+		p.customCounterLabelsProvider = f
+		p.customCounterLabels = labels
+	}
+}

--- a/prom_test.go
+++ b/prom_test.go
@@ -368,7 +368,7 @@ func TestEmptyRouter(t *testing.T) {
 
 func TestCustomCounterMetrics(t *testing.T) {
 	r := gin.New()
-	p := New(Engine(r), CustomCounterLabels([]string{"client_id", "tenant_id"}, func(c *gin.Context) map[string]string {
+	p := New(Engine(r), Registry(prometheus.NewRegistry()), CustomCounterLabels([]string{"client_id", "tenant_id"}, func(c *gin.Context) map[string]string {
 		clientId := c.GetHeader("X-Client-ID")
 		if clientId == "" {
 			clientId = "unknown"


### PR DESCRIPTION
Add support to custom labels for in the counter metric.

Closes https://github.com/Depado/ginprom/issues/61

The test passes if you launch it alone, but fails when launching all with this message:
```panic: a previously registered descriptor with the same fully-qualified name as...```

I don't have enough experience with golang and the source code to fix it.