### PR TITLE
feat: add custom histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Inspired by [github.com/zsais/go-gin-prometheus](https://github.com/zsais/go-gin
 - [Differences with go-gin-prometheus](#differences-with-go-gin-prometheus)
 - [Usage](#usage)
 - [Options](#options)
-	- [Custom Counters](#custom-counters)
+	- [Custom counters](#custom-counters)
 	- [Custom gauges](#custom-gauges)
+	- [Custom histograms](#custom-histograms)
 	- [Path](#path)
 	- [Namespace](#namespace)
 	- [Subsystem](#subsystem)
@@ -76,7 +77,7 @@ func main() {
 
 ## Options
 
-### Custom Counters
+### Custom counters
 
 Add custom counters to add own values to the metrics
 
@@ -112,6 +113,23 @@ Save `p` and use the following functions:
 - IncrementGaugeValue
 - DecrementGaugeValue
 - SetGaugeValue
+
+### Custom histograms
+
+Add custom histograms to add own values to the metrics
+
+```go
+r := gin.New()
+p := ginprom.New(
+  ginprom.Engine(r),
+)
+p.AddCustomHistogram("internal_request_latency", "Duration of internal HTTP requests", []string{"url", "method", "status"})
+r.Use(p.Instrument())
+```
+
+Save `p` and use the following functions:
+
+- AddCustomHistogramValue
 
 ### Path
 

--- a/prom_test.go
+++ b/prom_test.go
@@ -432,11 +432,13 @@ func TestCustomHistogram(t *testing.T) {
 	defer unregister(p)
 
 	r.GET("/ping", func(c *gin.Context) {
-		p.AddCustomHistogramValue("request_latency", []string{"http://example.com/status", "GET"}, 0.45)
+		err := p.AddCustomHistogramValue("request_latency", []string{"http://example.com/status", "GET"}, 0.45)
+		assert.NoError(t, err)
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 	r.GET("/pong", func(c *gin.Context) {
-		p.AddCustomHistogramValue("request_latency", []string{"http://example.com/status", "GET"}, 9.56)
+		err := p.AddCustomHistogramValue("request_latency", []string{"http://example.com/status", "GET"}, 9.56)
+		assert.NoError(t, err)
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 

--- a/prom_test.go
+++ b/prom_test.go
@@ -441,6 +441,12 @@ func TestCustomHistogram(t *testing.T) {
 		assert.NoError(t, err)
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
+	r.GET("/error", func(c *gin.Context) {
+		// Metric not found
+		err := p.AddCustomHistogramValue("invalid", []string{}, 9.56)
+		assert.Error(t, err)
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
 
 	expectedLines := []string{
 		`gin_gonic_request_latency_bucket{method="GET",url="http://example.com/status",le="0.005"} 0`,
@@ -473,6 +479,9 @@ func TestCustomHistogram(t *testing.T) {
 		assert.Equal(t, http.StatusOK, r.Code)
 	})
 	g.GET("/pong").Run(r, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+		assert.Equal(t, http.StatusOK, r.Code)
+	})
+	g.GET("/error").Run(r, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
 		assert.Equal(t, http.StatusOK, r.Code)
 	})
 


### PR DESCRIPTION
It's useful to enable users to add their custom histograms. For example, an API may send requests to other systems. With a custom histogram it could monitor the duration of each internal request.